### PR TITLE
force 'https' in output from Archive.st

### DIFF
--- a/archivenow/handlers/st_handler.py
+++ b/archivenow/handlers/st_handler.py
@@ -34,6 +34,9 @@ class ST_handler(object):
                 new_results = re_exists_url.findall(page)
                 msg = new_results[0]
 
+            msg = msg.replace('http://', 'https://')
+            msg = msg.replace('Archive.st', 'archive.st')
+
         except Exception as e:
             msg = "ERROR: ({0})".format(e)
 


### PR DESCRIPTION
* Force 'https' in the result returned from Archive.st whether it is a found result or not.
* fix URL returned from Archive.st to show "archive.st" rather than "Archive.st"