### PR TITLE
Updating domain for Archive.today

### DIFF
--- a/archivenow/handlers/is_handler.py
+++ b/archivenow/handlers/is_handler.py
@@ -5,7 +5,7 @@ class IS_handler(object):
 
     def __init__(self):
         self.enabled = True
-        self.name = 'The Archive.is'
+        self.name = 'The Archive.today'
         self.api_required = False 
 
     def push(self, uri_org, p_args=[]):
@@ -25,10 +25,10 @@ class IS_handler(object):
 
             archiveTodaySubmitId = ""
 
-            archiveTodayUserAgent = {"User-Agent": "Mozilla/5.0 (X11; Linux x86_64)" , "host": "archive.is"}
+            archiveTodayUserAgent = {"User-Agent": "Mozilla/5.0 (X11; Linux x86_64)" , "host": "archive.li"}
 
             # get the newest submitid required to push pages
-            host = 'archive.is'
+            host = 'archive.li'
             if from_heroku:
                 host = '178.62.195.5' # or 151.236.217.7
             rid = requests.get('http://'+host+'/',timeout=120, allow_redirects=True, headers=archiveTodayUserAgent)


### PR DESCRIPTION
The domain archive.is now redirects to archive.li. Without updating this a consistent error this script gets stuck on is "Exceeded 30 redirects"