### PR TITLE
Use a smaller base image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3-alpine3.10
 LABEL maintainer "Mohamed Aturban <mohsci1@yahoo.com>"
 
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3-alpine3.10
+ARG PYTAG=latest
+FROM python:${PYTAG}
 LABEL maintainer "Mohamed Aturban <mohsci1@yahoo.com>"
 
 WORKDIR /app


### PR DESCRIPTION
The base image `python:3` is too large, reaching 957 MB, and replacing it with `python:3-alpine3.10` is only 82 MB, which is not only a smaller disk footprint but also more secure.